### PR TITLE
docs: rewrite the README for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,92 @@
-# Documentation
+# UXP for Adobe Media Encoder: Developer Documentation
 
-Please see the [ADP Developer Site Documentation](https://developer-stage.adobe.com/dev-docs-reference/).
+This repository is the content source for the **UXP for Adobe Media Encoder**
+developer documentation. It covers building UXP plugins and automation for
+Adobe Media Encoder: setting up your tools, writing your first plugin, and using
+the Media Encoder APIs.
+
+The site is built on Adobe's EDS / devsite platform. Pages are authored as
+Markdown under [`src/pages/`](src/pages/) and rendered under the
+`/media-encoder/uxp/` path on the [Adobe Developer site](https://developer.adobe.com/).
+
+## Repository layout
+
+| Path | Contents |
+| --- | --- |
+| `src/pages/` | All documentation pages, one folder per page with an `index.md`. |
+| `src/pages/config.md` | Site navigation (sidebar, top nav) and the URL path prefix. |
+| `src/pages/images/` | Screenshots and other page assets. |
+| `package.json` | Authoring and lint scripts (see below). |
+
+## Develop locally
+
+Local preview needs three servers running at the same time: this content repo,
+the EDS code server, and the runtime connector. More detail lives in the
+[`adp-devsite-utils`](https://github.com/AdobeDocs/adp-devsite-utils) repo.
+
+1. Clone, install, and run this **content** repo:
+
+   ```sh
+   git clone https://github.com/AdobeDocs/uxp-media-encoder
+   cd uxp-media-encoder
+   npm install
+   npm run dev
+   ```
+
+2. Clone, install, and run the **code** server ([adp-devsite](https://github.com/AdobeDocs/adp-devsite)):
+
+   ```sh
+   git clone https://github.com/AdobeDocs/adp-devsite
+   cd adp-devsite
+   npm install
+   npm run dev
+   ```
+
+3. Clone, install, and run the **runtime connector** ([devsite-runtime-connector](https://github.com/aemsites/devsite-runtime-connector)):
+
+   ```sh
+   git clone https://github.com/aemsites/devsite-runtime-connector
+   cd devsite-runtime-connector
+   npm install
+   npm run dev
+   ```
+
+Then open [http://localhost:3000/media-encoder/uxp/](http://localhost:3000/media-encoder/uxp/).
+Use the exact path prefix, including the trailing slash.
+
+## Make changes
+
+- **Add or edit a page:** create or edit an `index.md` inside a folder under
+  `src/pages/`. Each page needs YAML frontmatter (`title`, `description`,
+  `keywords`).
+- **Change navigation:** edit `src/pages/config.md`. After changing it, stop the
+  content server, restart it, and reload the page in a new browser tab.
+- **Link and image paths** are relative to the page's folder.
+
+### Markdown rules
+
+EDS is stricter than local Markdown preview, so a page can look fine locally and
+break once deployed. The two that bite most often:
+
+- **No em dashes (`—`) or en dashes (`–`).** They render locally but turn into
+  garbage characters on deploy. Use commas, parentheses, or colons, and a single
+  hyphen (`-`) only for compound modifiers and ranges.
+- **Comment syntax is `{/* ... */}`**, not `<!-- ... -->`.
+
+## Scripts
+
+Run these from the repo root with `npm run <script>`:
+
+| Script | What it does |
+| --- | --- |
+| `dev` | Start the local content server. |
+| `lint` | Run the docs linter (Markdown rules, links). |
+| `link:checkAllLinks` | Check internal and external links. |
+| `buildNavigation` | Regenerate navigation from `config.md`. |
+| `buildContributors` | Regenerate the contributors list. |
+| `buildRedirections` | Regenerate redirects. |
+
+## Maintainers
+
+This documentation is maintained by **UXP DevRels**. For questions or issues,
+open an issue in this repository.


### PR DESCRIPTION
## What

Replaces the placeholder README (two lines linking to the dev site) with a
proper guide for anyone working on this documentation repo.

### Added
- **Overview** of what the repo is and where it renders (`/media-encoder/uxp/`).
- **Repository layout** table (`src/pages/`, `config.md`, `images/`).
- **Develop locally** - the three-server EDS setup (this content repo,
  `adp-devsite`, `devsite-runtime-connector`) with the correct install/run
  commands and localhost URL.
- **Make changes** - how to add pages and navigation, plus the EDS Markdown
  rules that matter on deploy (no em/en dashes, `{/* */}` comments).
- **Scripts** table pulled from `package.json` (`dev`, `lint`, link checks,
  `buildNavigation`, `buildContributors`, `buildRedirections`).
- **Maintainers** - UXP DevRels.