### PR TITLE
Update UXP Developer Tools Download Links

### DIFF
--- a/src/pages/get-started/developer-tools/index.md
+++ b/src/pages/get-started/developer-tools/index.md
@@ -50,9 +50,9 @@ Admin privileges are required
 
 UDT needs administrator-level privileges to run correctly. If you cannot get elevated permissions on your machine, you may not be able to use it.
 
-Install UDT directly [from Creative Cloud](https://creativecloud.adobe.com/apps/download/uxp-developer-tools), or follow these steps:
+Install UDT directly [from Creative Cloud](https://www.adobe.com/download/uxp-developer-tools), or follow these steps:
 
-1. Open the Adobe Creative Cloud desktop app. If you don't have it, [download and install it first](https://creativecloud.adobe.com/apps/download/creative-cloud).
+1. Open the Adobe Creative Cloud desktop app. If you don't have it, [download and install it first](https://www.adobe.com/download/creative-cloud).
 2. Sign in with your Adobe ID.
 3. Go to the **All apps** section and search for "UXP Developer Tools".
 4. Click **Install** on the UXP Developer Tools card.


### PR DESCRIPTION
## Description

Updated the UXP Developer Tools installation links in `get-started/developer-tools` to point to `www.adobe.com/download` instead of the outdated `creativecloud.adobe.com/apps/download` URLs.

## Related Issue

N/A

## Motivation and Context

The `creativecloud.adobe.com/apps/download` links are outdated. `www.adobe.com/download` is the current destination for Adobe downloads.

## How Has This Been Tested?

Ran `npm run lint` successfully with 0 errors and 0 warnings across all 31 Markdown files.

## Screenshots (if appropriate)

N/A

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.